### PR TITLE
Fix link to ExecutorPlugins for Spark 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SparkExecutorPlugins for Spark 2.4
 Code with examples of Spark Executor Plugins for Spark 2.4.x  
 Spark 3.0.0 is expected to have an extended and incompatible API,
-[see Spark 3.0.0 examples](https://github.com/cerndb/SparkExecutorPlugins)  
+[see Spark 3.0.0 examples](https://github.com/cerndb/SparkPlugins)  
 Contact: Luca.Canali@cern.ch
 
 **Build** with: `sbt +package`  


### PR DESCRIPTION
* I found this repo while searching for SparkExecutorPlugins on Google and it is very helpful to learn more about this concept
* given that Spark 2.4.x is outdated since a while your other repo https://github.com/cerndb/SparkPlugins is more relevant these days
* this PR fixes the link to the Spark 3.x executor plugins repo